### PR TITLE
added greater than and less than compare operators to IPurePath 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ TestResults
 *.sln.docstates
 *.ide
 
+# Visual Studio cache/options directory
+*.vs
+
 # Build results
 [Dd]ebug/
 [Rr]elease/

--- a/PathLib.UnitTest/PurePathUnitTest.cs
+++ b/PathLib.UnitTest/PurePathUnitTest.cs
@@ -62,16 +62,7 @@ namespace PathLib.UnitTest
 
                 if (String.IsNullOrEmpty(remainingPath) == false)
                 {
-
                     return _getFileNameOrDirectoryName(remainingPath, currentDirectoryIdentifier);
-                    if (remainingPath != currentDirectoryIdentifier)
-                    {
-                        return PathUtils.GetFileNameWithoutExtension(remainingPath, PathSeparator);
-                    }
-                    else
-                    {
-                        return currentDirectoryIdentifier;
-                    }
                 }
 
                 return null;

--- a/PathLib.UnitTest/PurePathUnitTest.cs
+++ b/PathLib.UnitTest/PurePathUnitTest.cs
@@ -29,7 +29,8 @@ namespace PathLib.UnitTest
             public string? ParseDrive(string path)
             {
                 return !String.IsNullOrEmpty(path)
-                    ? PathLib.Utils.PathUtils.GetPathRoot(path, PathSeparator).TrimEnd(PathSeparator[0])
+                    ? PathLib.Utils.PathUtils.GetPathRoot(path, PathSeparator)
+                        .TrimEnd(PathSeparator[0])
                     : null;
             }
 
@@ -45,9 +46,8 @@ namespace PathLib.UnitTest
                 {
                     return PathSeparator;
                 }
-                return root.EndsWith(PathSeparator)
-                           ? PathSeparator
-                           : null;
+
+                return root.EndsWith(PathSeparator) ? PathSeparator : null;
             }
 
             public string ParseDirname(string remainingPath)
@@ -58,9 +58,11 @@ namespace PathLib.UnitTest
             public string? ParseBasename(string remainingPath)
             {
                 var currentDirectoryIdentifier = PathLib.Utils.PathUtils.CurrentDirectoryIdentifier;
+
                 return !String.IsNullOrEmpty(remainingPath)
                     ? remainingPath != currentDirectoryIdentifier
-                        ? PathLib.Utils.PathUtils.GetFileNameWithoutExtension(remainingPath, PathSeparator)
+                        ?
+                        PathLib.Utils.PathUtils.GetFileNameWithoutExtension(remainingPath, PathSeparator)
                         : currentDirectoryIdentifier
                     : null;
             }
@@ -79,23 +81,29 @@ namespace PathLib.UnitTest
                     if (path.IndexOf(ch) >= 0)
                     {
                         reservedCharacter = ch;
+
                         return true;
                     }
                 }
+
                 reservedCharacter = default(char);
+
                 return false;
             }
         }
 
         private class MockPath : PurePath<MockPath>
         {
-            public MockPath(params string[] paths)
-                : base(new MockParser(@"\"), paths)
-            { }
+            public MockPath(params string[] paths) : base(new MockParser(@"\"), paths)
+            {
+            }
 
-            public MockPath(string drive, string root, string dirname, string basename, string extension)
-                : base(drive, root, dirname, basename, extension)
-            { }
+            public MockPath(
+                string drive, string root, string dirname,
+                string basename, string extension) : base(drive, root, dirname,
+                basename, extension)
+            {
+            }
 
             protected override string PathSeparator
             {
@@ -114,49 +122,46 @@ namespace PathLib.UnitTest
                 {
                     return false;
                 }
-                return Drive == other.Drive &&
-                       Root == other.Root &&
-                       Dirname == other.Dirname &&
-                       Basename == other.Basename &&
-                       Extension == other.Extension;
+
+                return Drive == other.Drive && Root == other.Root && Dirname == other.Dirname &&
+                       Basename == other.Basename && Extension == other.Extension;
             }
 
             public override int GetHashCode()
             {
-                return (Drive ?? "").GetHashCode() +
-                       (Root ?? "").GetHashCode() +
-                       (Dirname ?? "").GetHashCode() +
-                       (Basename ?? "").GetHashCode() +
-                       (Extension ?? "").GetHashCode();
+                return (Drive ?? "").GetHashCode() + (Root ?? "").GetHashCode() + (Dirname ?? "").GetHashCode() +
+                       (Basename ?? "").GetHashCode() + (Extension ?? "").GetHashCode();
             }
 
             public override bool IsReserved()
             {
-                throw new NotImplementedException(
-                    "A mock should not be used to test this.");
+                throw new NotImplementedException("A mock should not be used to test this.");
             }
 
             public override bool Match(string pattern)
             {
-                throw new NotImplementedException(
-                    "A mock should not be used to test this.");
+                throw new NotImplementedException("A mock should not be used to test this.");
             }
 
             public override MockPath NormCase(CultureInfo currentCulture)
             {
-                throw new NotImplementedException(
-                    "A mock should not be used to test this.");
+                throw new NotImplementedException("A mock should not be used to test this.");
             }
 
             protected override MockPath PurePathFactory(string path)
             {
-                return new MockPath(new [] {path});
+                return new MockPath(new[]
+                {
+                    path
+                });
             }
 
             protected override MockPath PurePathFactoryFromComponents(
-                string drive, string root, string dirname, string basename, string extension)
+                string drive, string root, string dirname,
+                string basename, string extension)
             {
-                return new MockPath(drive, root, dirname, basename, extension);
+                return new MockPath(drive, root, dirname,
+                    basename, extension);
             }
         }
 
@@ -176,6 +181,7 @@ namespace PathLib.UnitTest
 
             Assert.Equal(path1, path2);
         }
+
         [Fact]
         public void Constructor_WithSameInputAndDifferentSeparator_CreatesEqualPaths()
         {
@@ -208,7 +214,7 @@ namespace PathLib.UnitTest
         {
             var expected = new MockPath(@"a\b");
             var actual = new MockPath("a", "b");
-            
+
             Assert.Equal(expected, actual);
         }
 
@@ -217,7 +223,7 @@ namespace PathLib.UnitTest
         {
             var expected = new MockPath(@"a\b");
             var actual = new MockPath(@"a", @"b\");
-            
+
             Assert.Equal(expected, actual);
         }
 
@@ -235,7 +241,7 @@ namespace PathLib.UnitTest
         {
             var expected = new MockPath(@"a\\b\");
             var actual = new MockPath(@"a\b");
-            
+
             Assert.Equal(expected, actual);
         }
 
@@ -244,7 +250,7 @@ namespace PathLib.UnitTest
         {
             var expected = new MockPath(@"a\b");
             var actual = new MockPath("", "a", "b");
-            
+
             Assert.Equal(expected, actual);
         }
 
@@ -253,7 +259,7 @@ namespace PathLib.UnitTest
         {
             var expected = new MockPath(@"a\b");
             var actual = new MockPath("a", "", "b");
-            
+
             Assert.Equal(expected, actual);
         }
 
@@ -262,7 +268,7 @@ namespace PathLib.UnitTest
         {
             var expected = new MockPath(@"\b\c");
             var actual = new MockPath(@"a", @"\b", @"c");
-            
+
             Assert.Equal(expected, actual);
         }
 
@@ -271,7 +277,7 @@ namespace PathLib.UnitTest
         {
             var expected = new MockPath(@"\b\c");
             var actual = new MockPath(@"a", @"\b\\", @"c");
-            
+
             Assert.Equal(expected, actual);
         }
 
@@ -280,7 +286,7 @@ namespace PathLib.UnitTest
         {
             var expected = new MockPath(@"a\b");
             var actual = new MockPath("a", "b", "");
-            
+
             Assert.Equal(expected, actual);
         }
 
@@ -289,7 +295,7 @@ namespace PathLib.UnitTest
         {
             var expected = new MockPath(@"a\b");
             var actual = new MockPath(@"\a\b");
-            
+
             Assert.NotEqual(expected, actual);
         }
 
@@ -461,7 +467,8 @@ namespace PathLib.UnitTest
 
             var expected = new MockPath(@"C:\");
 
-            var parents = path.Parents().GetEnumerator();
+            var parents = path.Parents()
+                .GetEnumerator();
             parents.MoveNext();
             var actual = parents.Current;
 
@@ -474,10 +481,9 @@ namespace PathLib.UnitTest
             var path = new MockPath(@"C:\users\nemec");
 
             var expected = new[]
-                {
-                    new MockPath(@"C:\users"),
-                    new MockPath(@"C:\")
-                };
+            {
+                new MockPath(@"C:\users"), new MockPath(@"C:\")
+            };
 
             Assert.True(expected.SequenceEqual(path.Parents()));
         }
@@ -528,7 +534,10 @@ namespace PathLib.UnitTest
         [Fact]
         public void GetExtensions_WithMultipleExtensions_ReturnsExtensionsInOrder()
         {
-            var expected = new [] {".txt", ".tar", ".gz"};
+            var expected = new[]
+            {
+                ".txt", ".tar", ".gz"
+            };
             var path = new MockPath(@"c:\users\nemec\file.txt.tar.gz");
 
             var actual = path.Extensions;
@@ -550,7 +559,7 @@ namespace PathLib.UnitTest
         [Fact]
         public void GetBasenameWithoutExtension_WithExtension_ReturnsBasename()
         {
-            
+
             var path = new MockPath(@"c:\users\nemec\file.txt");
 
             var expected = path.Basename;
@@ -825,14 +834,89 @@ namespace PathLib.UnitTest
             }
 
             const string path = @"C:\users\tmp";
-            var converter = TypeDescriptor.GetConverter(typeof (IPurePath));
-            var expected = isWindows
-                ? typeof (PureWindowsPath)
-                : typeof (PurePosixPath);
+            var converter = TypeDescriptor.GetConverter(typeof(IPurePath));
+            var expected = isWindows ? typeof(PureWindowsPath) : typeof(PurePosixPath);
 
             var actual = converter.ConvertFromInvariantString(path);
 
             Assert.IsType(expected, actual);
         }
+
+
+        #region Equality Testing
+
+        [Fact]
+        public void Compare_Directory_With_Directory_ShouldBeEqual()
+        {
+            var firstPath = @"C:\foo\bar";
+            var secondPath = @"C:\foo\bar";
+            var firstPurePath = PurePath.Create(firstPath);
+            var secondPurePath = PurePath.Create(secondPath);
+            Assert.Equal(firstPurePath , secondPurePath);
+            
+
+        }
+        [Fact]
+        public void Compare_Directory_With_Directory_OneWithTrailingSlash_ShouldBeEqual()
+        {
+            var firstPath = @"C:\foo\bar";
+            var secondPath = @"C:\foo\bar\";
+            var firstPurePath = PurePath.Create(firstPath);
+            var secondPurePath = PurePath.Create(secondPath);
+            Assert.Equal(firstPurePath , secondPurePath);
+            
+
+        }
+
+        [Fact]
+        public void Compare_Directory_With_SubDirectory_ShouldBeNotEqual()
+        {
+            var firstPath = @"C:\foo\bar";
+            var secondPath = @"C:\foo\bar\other";
+            var firstPurePath = PurePath.Create(firstPath);
+            var secondPurePath = PurePath.Create(secondPath);
+            Assert.NotEqual(firstPurePath , secondPurePath);
+            
+
+        }
+
+        
+        [Fact]
+        public void Compare_Directory_With_TopLevelFile_ShouldBeNotEqual()
+        {
+            var firstPath = @"C:\foo\bar\";
+            var secondPath = @"C:\foo\bar\file.txt";
+            var firstPurePath = PurePath.Create(firstPath);
+            var secondPurePath = PurePath.Create(secondPath);
+            Assert.NotEqual(firstPurePath , secondPurePath);
+        }
+
+        [Fact]
+        public void Compare_ParentDirectory_IsLessThan_ChildDirectory()
+        {
+            var parentPath = @"C:\foo\bar";
+            var childPath = @"C:\foo\bar\other";
+          
+
+            var parentPurePath = PurePath.Create(parentPath);
+            var childPurePath = PurePath.Create(childPath);
+      
+            Assert.True(parentPurePath < childPurePath);
+        }
+
+
+        [Fact]
+        public void Compare_ChildDirectory_IsGreaterThan_ParentDirectory()
+        {
+            var parentPath = @"C:\foo\bar";
+            var childPath = @"C:\foo\bar\other";
+            var purePathFactory = new PurePathFactory();
+            var parentPurePath = PurePath.Create(parentPath);
+            var childPurePath = PurePath.Create(childPath);
+      
+            Assert.True(childPurePath > parentPurePath );
+        }
+
+    #endregion
     }
 }

--- a/PathLib.UnitTest/PurePathUnitTest.cs
+++ b/PathLib.UnitTest/PurePathUnitTest.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
+using PathLib.Utils;
 using Xunit;
 
 namespace PathLib.UnitTest
@@ -59,12 +60,33 @@ namespace PathLib.UnitTest
             {
                 var currentDirectoryIdentifier = PathLib.Utils.PathUtils.CurrentDirectoryIdentifier;
 
-                return !String.IsNullOrEmpty(remainingPath)
-                    ? remainingPath != currentDirectoryIdentifier
-                        ?
-                        PathLib.Utils.PathUtils.GetFileNameWithoutExtension(remainingPath, PathSeparator)
-                        : currentDirectoryIdentifier
-                    : null;
+                if (String.IsNullOrEmpty(remainingPath) == false)
+                {
+
+                    return _getFileNameOrDirectoryName(remainingPath, currentDirectoryIdentifier);
+                    if (remainingPath != currentDirectoryIdentifier)
+                    {
+                        return PathUtils.GetFileNameWithoutExtension(remainingPath, PathSeparator);
+                    }
+                    else
+                    {
+                        return currentDirectoryIdentifier;
+                    }
+                }
+
+                return null;
+
+                string _getFileNameOrDirectoryName(string remainingPathString, string currentDirIdentifier)
+                {
+                    if (remainingPath != currentDirectoryIdentifier)
+                    {
+                        return PathUtils.GetFileNameWithoutExtension(remainingPath, PathSeparator);
+                    }
+                    else
+                    {
+                        return currentDirectoryIdentifier;
+                    }
+                }
             }
 
             public string? ParseExtension(string remainingPath)
@@ -551,7 +573,7 @@ namespace PathLib.UnitTest
             const int expected = 0;
             var path = new MockPath(@"c:\users\nemec\.bashrc");
 
-            var actual = path.Extensions.Count();
+            var actual = Enumerable.Count(path.Extensions);
 
             Assert.Equal(expected, actual);
         }

--- a/PathLib.UnitTest/PurePathUnitTest.cs
+++ b/PathLib.UnitTest/PurePathUnitTest.cs
@@ -845,8 +845,10 @@ namespace PathLib.UnitTest
 
         #region Equality Testing
 
-        [Fact]
-        public void Compare_Directory_With_Directory_ShouldBeEqual()
+        #region Windows Paths
+
+          [Fact]
+        public void Compare_WindowsFormat_Directory_With_Directory_ShouldBeEqual()
         {
             var firstPath = @"C:\foo\bar";
             var secondPath = @"C:\foo\bar";
@@ -857,7 +859,7 @@ namespace PathLib.UnitTest
 
         }
         [Fact]
-        public void Compare_Directory_With_Directory_OneWithTrailingSlash_ShouldBeEqual()
+        public void Compare_WindowsFormat_Directory_With_Directory_OneWithTrailingSlash_ShouldBeEqual()
         {
             var firstPath = @"C:\foo\bar";
             var secondPath = @"C:\foo\bar\";
@@ -869,7 +871,7 @@ namespace PathLib.UnitTest
         }
 
         [Fact]
-        public void Compare_Directory_With_SubDirectory_ShouldBeNotEqual()
+        public void Compare_WindowsFormat_Directory_With_SubDirectory_ShouldBeNotEqual_ShouldBeTrue()
         {
             var firstPath = @"C:\foo\bar";
             var secondPath = @"C:\foo\bar\other";
@@ -882,7 +884,7 @@ namespace PathLib.UnitTest
 
         
         [Fact]
-        public void Compare_Directory_With_TopLevelFile_ShouldBeNotEqual()
+        public void Compare_WindowsFormat_Directory_With_TopLevelFile_ShouldBeNotEqual()
         {
             var firstPath = @"C:\foo\bar\";
             var secondPath = @"C:\foo\bar\file.txt";
@@ -892,7 +894,7 @@ namespace PathLib.UnitTest
         }
 
         [Fact]
-        public void Compare_ParentDirectory_IsLessThan_ChildDirectory()
+        public void Compare_WindowsFormat_ParentDirectory_IsLessThan_ChildDirectory_ShouldBeTrue()
         {
             var parentPath = @"C:\foo\bar";
             var childPath = @"C:\foo\bar\other";
@@ -906,7 +908,7 @@ namespace PathLib.UnitTest
 
 
         [Fact]
-        public void Compare_ChildDirectory_IsGreaterThan_ParentDirectory()
+        public void Compare_WindowsFormat_ChildDirectory_IsGreaterThan_ParentDirectory_ShouldBeTrue()
         {
             var parentPath = @"C:\foo\bar";
             var childPath = @"C:\foo\bar\other";
@@ -916,6 +918,108 @@ namespace PathLib.UnitTest
       
             Assert.True(childPurePath > parentPurePath );
         }
+
+
+        [Fact]
+        public void Compare_WindowsFormat_DifferentDrives_ChildDirectory_IsGreaterThan_ParentDirectory_ShouldBeFalse()
+        {
+            var parentPath = @"C:\foo\bar";
+            var childPath = @"D:\foo\bar\other";
+            var purePathFactory = new PurePathFactory();
+            var parentPurePath = PurePath.Create(parentPath);
+            var childPurePath = PurePath.Create(childPath);
+      
+            Assert.False(childPurePath > parentPurePath );
+        }
+
+        #endregion
+
+        #region Posix Paths
+
+          [Fact]
+        public void Compare_PosixFormat_Directory_With_Directory_ShouldBeEqual()
+        {
+            var firstPath = @"/mnt/dev/parent";
+            var secondPath = @"/mnt/dev/parent";
+            var firstPurePath = PurePath.Create(firstPath);
+            var secondPurePath = PurePath.Create(secondPath);
+            Assert.Equal(firstPurePath , secondPurePath);
+            
+
+        }
+        [Fact]
+        public void Compare_PosixFormat_Directory_With_Directory_OneWithTrailingSlash_ShouldBeEqual()
+        {
+            var firstPath = @"/mnt/dev/parent/";
+            var secondPath = @"/mnt/dev/parent";
+            var firstPurePath = PurePath.Create(firstPath);
+            var secondPurePath = PurePath.Create(secondPath);
+            Assert.Equal(firstPurePath , secondPurePath);
+            
+
+        }
+
+        [Fact]
+        public void Compare_PosixFormat_Directory_With_SubDirectory_ShouldBeNotEqual_ShouldBeTrue()
+        {
+            var parentPath = @"/mnt/dev/parent/";
+            var childPath = @"/mnt/dev/parent/someChild";
+            var firstPurePath = PurePath.Create(parentPath);
+            var secondPurePath = PurePath.Create(childPath);
+            Assert.NotEqual(firstPurePath , secondPurePath);
+            
+
+        }
+
+        
+        [Fact]
+        public void Compare_PosixFormat_Directory_With_TopLevelFile_ShouldBeNotEqual_ShouldBeTrue()
+        {
+            var parentPath = @"/mnt/dev/parent/";
+            var childPath = @"/mnt/dev/parent/someChild/someFile.txt";
+            var firstPurePath = PurePath.Create(parentPath);
+            var secondPurePath = PurePath.Create(childPath);
+            Assert.NotEqual(firstPurePath , secondPurePath);
+        }
+
+        [Fact]
+        public void Compare_PosixFormat_ParentDirectory_IsLessThan_ChildDirectory_ShouldBeTrue()
+        {
+            var parentPath = @"/mnt/dev/parent";
+            var childPath = @"/mnt/dev/parent/someChild";
+          
+
+            var parentPurePath = PurePath.Create(parentPath);
+            var childPurePath = PurePath.Create(childPath);
+      
+            Assert.True(parentPurePath < childPurePath);
+        }
+
+
+        [Fact]
+        public void Compare_PosixFormat_ChildDirectory_IsGreaterThan_ParentDirectory_ShouldBeTrue()
+        {
+            var parentPath = @"/mnt/dev/parent";
+            var childPath = @"/mnt/dev/parent/someChild";
+            var purePathFactory = new PurePathFactory();
+            var parentPurePath = PurePath.Create(parentPath);
+            var childPurePath = PurePath.Create(childPath);
+      
+            Assert.True(childPurePath > parentPurePath );
+        }
+        [Fact]
+        public void Compare_PosixFormat__DifferentRoots_ChildDirectory_IsGreaterThan_ParentDirectory_ShouldBeFalse()
+        {
+            var parentPath = @"/mnt/other/parent";
+            var childPath = @"/dev/other/parent/someChild";
+            var purePathFactory = new PurePathFactory();
+            var parentPurePath = PurePath.Create(parentPath);
+            var childPurePath = PurePath.Create(childPath);
+      
+            Assert.False(childPurePath > parentPurePath );
+        }
+
+        #endregion
 
     #endregion
     }

--- a/PathLib.UnitTest/PureWindowsPathUnitTest.cs
+++ b/PathLib.UnitTest/PureWindowsPathUnitTest.cs
@@ -6,6 +6,7 @@ using System.Xml.Serialization;
 using System.Xml;
 using Xunit;
 using System.Text;
+using PathLib;
 
 namespace PathLib.UnitTest
 {
@@ -410,5 +411,25 @@ namespace PathLib.UnitTest
             Assert.NotNull(obj);
             Assert.Equal(expected, obj!.Folder);
         }
+
+        [Fact]
+        public void CompareDirectoryHierarchy_FromDir_ToDir_ShouldShowParentAbove()
+        {
+            var parentPath = @"c:\foo\bar";
+            var childPath = @"c:\foo\bar\child\path";
+
+            var parentWindowsPath = new PureWindowsPath(parentPath);
+            var childWindowsPath = new PureWindowsPath(childPath);
+
+            Assert.True(childWindowsPath.IsChildOf(parentWindowsPath));
+        }
+    }
+}
+
+public static class PureWindowsPathExtensions
+{
+    public static bool IsChildOf(this PureWindowsPath target,PureWindowsPath compare)
+    {
+        return true;
     }
 }

--- a/PathLib.UnitTest/PureWindowsPathUnitTest.cs
+++ b/PathLib.UnitTest/PureWindowsPathUnitTest.cs
@@ -421,15 +421,21 @@ namespace PathLib.UnitTest
             var parentWindowsPath = new PureWindowsPath(parentPath);
             var childWindowsPath = new PureWindowsPath(childPath);
 
-            Assert.True(childWindowsPath.IsChildOf(parentWindowsPath));
+            Assert.True(childWindowsPath > parentWindowsPath);
+        }
+
+        [Fact]
+        public void CompareDirectoryHierarchy_DifferentDrives_FromDir_ToDir_ShouldBeFalse()
+        {
+            var parentPath = @"c:\foo\bar";
+            var childPath = @"d:\foo\bar\child\path";
+
+            var parentWindowsPath = new PureWindowsPath(parentPath);
+            var childWindowsPath = new PureWindowsPath(childPath);
+
+            Assert.False(childWindowsPath > parentWindowsPath);
         }
     }
 }
 
-public static class PureWindowsPathExtensions
-{
-    public static bool IsChildOf(this PureWindowsPath target,PureWindowsPath compare)
-    {
-        return true;
-    }
-}
+ 

--- a/PathLib.sln
+++ b/PathLib.sln
@@ -19,11 +19,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PathLib", "PathLib\PathLib.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PathLib.UnitTest.Posix", "PathLib.UnitTest.Posix\PathLib.UnitTest.Posix.csproj", "{3EB494F5-B992-47AD-BE63-01AE6DA6B6BC}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C3E2ADE8-26A2-4BCB-8211-B634E887FE7A}"
-	ProjectSection(SolutionItems) = preProject
-		.editorconfig = .editorconfig
-	EndProjectSection
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/PathLib.sln
+++ b/PathLib.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2027
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32228.430
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PathLib.UnitTest", "PathLib.UnitTest\PathLib.UnitTest.csproj", "{21D71FE8-3CB8-4AEC-B3C7-DA58A0A421AD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PathLib.UnitTest", "PathLib.UnitTest\PathLib.UnitTest.csproj", "{21D71FE8-3CB8-4AEC-B3C7-DA58A0A421AD}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{28598FE8-AC6D-4DA6-9845-7E45A39E6DC9}"
 	ProjectSection(SolutionItems) = preProject
@@ -11,13 +11,18 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{28598FE8-A
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PathLib.UnitTest.Windows", "PathLib.UnitTest.Windows\PathLib.UnitTest.Windows.csproj", "{144BD83D-B0C3-45D5-8C0D-96F250C5D94F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PathLib.UnitTest.Windows", "PathLib.UnitTest.Windows\PathLib.UnitTest.Windows.csproj", "{144BD83D-B0C3-45D5-8C0D-96F250C5D94F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PathLib.Benchmark", "PathLib.Benchmark\PathLib.Benchmark.csproj", "{7193929E-326F-47AD-98DD-1AC3AB0FDBB1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PathLib.Benchmark", "PathLib.Benchmark\PathLib.Benchmark.csproj", "{7193929E-326F-47AD-98DD-1AC3AB0FDBB1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PathLib", "PathLib\PathLib.csproj", "{D68D3477-112D-4D34-B255-FBEE778CD21F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PathLib", "PathLib\PathLib.csproj", "{D68D3477-112D-4D34-B255-FBEE778CD21F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PathLib.UnitTest.Posix", "PathLib.UnitTest.Posix\PathLib.UnitTest.Posix.csproj", "{3EB494F5-B992-47AD-BE63-01AE6DA6B6BC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PathLib.UnitTest.Posix", "PathLib.UnitTest.Posix\PathLib.UnitTest.Posix.csproj", "{3EB494F5-B992-47AD-BE63-01AE6DA6B6BC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C3E2ADE8-26A2-4BCB-8211-B634E887FE7A}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/PathLib/ConcretePath.cs
+++ b/PathLib/ConcretePath.cs
@@ -610,6 +610,14 @@ namespace PathLib
             return PurePath.GetComponents(components);
         }
 
+
+        #region IPurePath Equality
+
+  
+
+        #endregion
+
+
         #endregion
 
 

--- a/PathLib/IPurePath.cs
+++ b/PathLib/IPurePath.cs
@@ -148,7 +148,7 @@ namespace PathLib
             }
             foreach (var parts in parent.Zip(child, (p, c) => new [] {p, c}))
             {
-                if (!String.Equals(parts[0], parts[1], StringComparison.InvariantCultureIgnoreCase))
+                if (!String.Equals(parts[0], parts[1], StringComparison.InvariantCulture))
                 {
                     return false;
                 }

--- a/PathLib/IPurePath.cs
+++ b/PathLib/IPurePath.cs
@@ -5,6 +5,8 @@ using System.Globalization;
 
 namespace PathLib
 {
+    using Utils;
+
     /// <summary>
     /// Pure paths do not implement any IO operations and may be
     /// used cross-platform.
@@ -117,6 +119,55 @@ namespace PathLib
         public static IPurePath operator/ (IPurePath lvalue, IPurePath rvalue)
         {
             return lvalue.Join(rvalue);
+        }
+
+        
+        /// <summary>   compares of the first path is less than the second path. </summary>
+        ///
+        /// <remarks>   Jeff Ward, 5/4/2022. </remarks>
+        ///
+        /// <param name="first">    The first instance to compare. </param>
+        /// <param name="second">   The second instance to compare. </param>
+        ///
+        /// <returns>   The result of the operation. </returns>
+        public static bool operator <(IPurePath first, IPurePath second)
+        {
+            if (ReferenceEquals(first, null) || ReferenceEquals(second, null))
+            {
+                return false;
+            }
+
+            // Resolve symlinks before comparing
+            var parent = new List<string>(first.NormCase().Parts);
+            var child = new List<string>(second.NormCase().Parts);
+
+            // Parent must be shorter than child
+            if (parent.Count() >= child.Count())
+            {
+                return false;
+            }
+            foreach (var parts in parent.Zip(child, (p, c) => new [] {p, c}))
+            {
+                if (!String.Equals(parts[0], parts[1], StringComparison.InvariantCultureIgnoreCase))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        
+        /// <summary>   Compares if the first poth is greater than the second path. </summary>
+        ///
+        /// <remarks>   Jeff Ward, 5/4/2022. </remarks>
+        ///
+        /// <param name="first">    The first instance to compare. </param>
+        /// <param name="second">   The second instance to compare. </param>
+        ///
+        /// <returns>   The result of the operation. </returns>
+        public static bool operator >(IPurePath first, IPurePath second)
+        {
+            return second < first;
         }
 #endif
 
@@ -420,5 +471,8 @@ namespace PathLib
         /// <param name="newExtension"></param>
         /// <returns></returns>
         new TPath WithExtension(string newExtension);
+
+
+
     }
 }

--- a/PathLib/PurePath.cs
+++ b/PathLib/PurePath.cs
@@ -280,7 +280,7 @@ namespace PathLib
                 yield return part;
             }
 
-            if (Filename != string.Empty)
+            if (Filename != String.Empty)
             {
                 yield return Filename;
             }
@@ -743,6 +743,27 @@ namespace PathLib
             // counts as a relative path in a different drive.
             return !String.IsNullOrEmpty(Root);
         }
+
+        #region Equality Members
+
+        /*
+        public static bool operator ==(PurePath<TPath> first, PurePath<TPath> second)
+        {
+            return ReferenceEquals(first, null) ?
+                ReferenceEquals(second, null) :
+                first.Equals(second);
+        }
+
+
+        public static bool operator !=(PurePath<TPath> first, PurePath<TPath> second)
+        {
+            return !(first == second);
+        }
+        */
+
+  
+        #endregion
+        
 
         /// <inheritdoc/>
         public abstract bool IsReserved();


### PR DESCRIPTION
# Task

* I added `<` and `>` operators to `IPurePath`

## Summary
To create a `IPurePath` this action must be performed:

````csharp
var someParentPath = @"C:\somePath\someDir";
var someChildPath =  @"C:\somePath\someDir\someChild\anotherChild";
var purePathFactory = new PurePathFactory();
var parentPurePath= purePathFactory.Create(someParentPath);
var childPurePath =  purePathFactory.Create(someChildPath);
````

Previously, you could not compare two `IPurePath` instances using `<` or `>`.
````csharp
var isTrue = parentPurePath < childPurepath;
// Previously this would throw a compiler error

````


I added operator compares to `IPurePath` within the `IPurePath.cs` file
````csharp
var isTrue = parentPurePath < childPurepath;
// Now this works and is evaluated correctly

````

