### PR TITLE
Added support for PosixPath.Resolve()

### DIFF
--- a/PathLib/Posix/Native.cs
+++ b/PathLib/Posix/Native.cs
@@ -1,4 +1,5 @@
 
+using System;
 using System.Runtime.InteropServices;
 using System.Text;
 // ReSharper disable MemberCanBePrivate.Global
@@ -47,7 +48,7 @@ namespace PathLib.Posix
     // Get typedef mappings for struct fields
     // gcc -E /usr/include/x86_64-linux-gnu/sys/types.h
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
-    public struct StatNative 
+    public struct StatNative
     {
         public ulong st_dev;
         public ulong st_ino;
@@ -129,12 +130,28 @@ namespace PathLib.Posix
     internal static class Native {
         [DllImport("libc", SetLastError = true, CharSet = CharSet.Auto, CallingConvention=CallingConvention.Cdecl)]
         public static extern int stat64(string path, out StatNative info);
-        
+
         [DllImport("libc", SetLastError = true, CharSet = CharSet.Auto, CallingConvention=CallingConvention.Cdecl)]
         public static extern int lstat(string path, out StatNative info);
-        
+
         [DllImport("libc", SetLastError = true, CharSet = CharSet.Auto, CallingConvention=CallingConvention.Cdecl)]
         public static extern long readlink(string path, StringBuilder buf, ulong bufsize);
+
+        [DllImport("libc", EntryPoint = "realpath", SetLastError = true, CharSet = CharSet.Auto, CallingConvention=CallingConvention.Cdecl)]
+        private static extern IntPtr _realpath(string path, IntPtr resolved_path);
+
+        public static string realpath(string path)
+        {
+            var ptr = _realpath(path, IntPtr.Zero);
+            if (ptr == IntPtr.Zero)
+            {
+                throw new Exception("realpath failed");
+            }
+
+            var result = Marshal.PtrToStringAuto(ptr);
+            Marshal.FreeHGlobal(ptr);
+            return result;
+        }
 
         /// <summary>
         /// S_IRUSR
@@ -152,7 +169,7 @@ namespace PathLib.Posix
         /// <summary>
         /// S_IRWXU
         /// </summary>
-        internal const uint UserBits = UserRead | UserWrite | UserExecute;  
+        internal const uint UserBits = UserRead | UserWrite | UserExecute;
         /// <summary>
         /// S_IRGRP
         /// </summary>

--- a/PathLib/Posix/Native.cs
+++ b/PathLib/Posix/Native.cs
@@ -140,12 +140,17 @@ namespace PathLib.Posix
         [DllImport("libc", EntryPoint = "realpath", SetLastError = true, CharSet = CharSet.Auto, CallingConvention=CallingConvention.Cdecl)]
         private static extern IntPtr _realpath(string path, IntPtr resolved_path);
 
+        [DllImport("libc", EntryPoint = "strerror", SetLastError = true, CharSet = CharSet.Auto, CallingConvention=CallingConvention.Cdecl)]
+        private static extern IntPtr _strerror(int errnum);
+
         public static string realpath(string path)
         {
             var ptr = _realpath(path, IntPtr.Zero);
             if (ptr == IntPtr.Zero)
             {
-                throw new Exception("realpath failed");
+                var errno = Marshal.GetLastWin32Error();
+                var error = Marshal.PtrToStringAuto(_strerror(errno));
+                throw new Exception($"realpath failed: {error} ({errno})");
             }
 
             var result = Marshal.PtrToStringAuto(ptr);

--- a/PathLib/Posix/PosixPath.cs
+++ b/PathLib/Posix/PosixPath.cs
@@ -141,8 +141,9 @@ namespace PathLib
         /// <inheritdoc/>
         public override PosixPath Resolve()
         {
-            throw new NotImplementedException();
-            //var size = Native.readlink(path, buf, 1024);
+            var path = ExpandUser().ExpandEnvironmentVars().ToString();
+            var realpath = Native.realpath(path) ?? throw new ApplicationException($"Resolve failed: realpath returned null");
+            return new PosixPath(realpath);
         }
 
         /// <inheritdoc/>
@@ -206,7 +207,7 @@ namespace PathLib
 
             return this;
         }
-        
+
         /// <inheritdoc/>
         public override IEnumerable<DirectoryContents<PosixPath>> WalkDir(Action<IOException> onError = null)
         {


### PR DESCRIPTION
Added support for `PosixPath.Resolve()` by delegating to [realpath(3)](https://man7.org/linux/man-pages/man3/realpath.3.html). Unit tests included.