### PR TITLE
Add a github action to run unit tests on Windows, Mac and Linux; fix some bugs in unit tests on windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,34 +1,34 @@
 # Run unit tests on GitHub actions manually, and for each pull request
 on:
-    pull_request:
-      branches: [ master ]
-    workflow_dispatch: null
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch: null
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os.runs-on }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: 
+          - runs-on: windows-latest
+            arch: win-x64
+          - runs-on: macos-13
+            arch: osx-x64
+          - runs-on: ubuntu-latest
+            arch: linux-x64
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Run general tests
+      run: dotnet test PathLib.UnitTest
   
-  jobs:
-    test:
-      runs-on: ${{ matrix.os.runs-on }}
-  
-      strategy:
-        fail-fast: false
-        matrix:
-          os: 
-            - runs-on: windows-latest
-              arch: win-x64
-            - runs-on: macos-13
-              arch: osx-x64
-            - runs-on: ubuntu-latest
-              arch: linux-x64
-  
-      steps:
-      - uses: actions/checkout@v1
-  
-      - name: Run general tests
-        run: dotnet test PathLib.UnitTest
+    - name: run Windows specific tests
+      if: ${{ matrix.os.runs-on == 'windows-latest' }}
+      run: dotnet test PathLib.UnitTest.Windows
     
-      - name: run Windows specific tests
-        if: ${{ matrix.os.runs-on == 'windows-latest' }}
-        run: dotnet test PathLib.UnitTest.Windows
-      
-      - name: run Posix specific tests
-        if: ${{ matrix.os.runs-on != 'windows-latest' }}
-        run: dotnet test PathLib.UnitTest.Posix
+    - name: run Posix specific tests
+      if: ${{ matrix.os.runs-on != 'windows-latest' }}
+      run: dotnet test PathLib.UnitTest.Posix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '6.0.x'
+
     - name: Run general tests
       run: dotnet test PathLib.UnitTest
   

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+# Run unit tests on GitHub actions manually, and for each pull request
+on:
+    pull_request:
+      branches: [ master ]
+    workflow_dispatch: null
+  
+  jobs:
+    test:
+      runs-on: ${{ matrix.os.runs-on }}
+  
+      strategy:
+        fail-fast: false
+        matrix:
+          os: 
+            - runs-on: windows-latest
+              arch: win-x64
+            - runs-on: macos-13
+              arch: osx-x64
+            - runs-on: ubuntu-latest
+              arch: linux-x64
+  
+      steps:
+      - uses: actions/checkout@v1
+  
+      - name: Run general tests
+        run: dotnet test PathLib.UnitTest
+    
+      - name: run Windows specific tests
+        if: ${{ matrix.os.runs-on == 'windows-latest' }}
+        run: dotnet test PathLib.UnitTest.Windows
+      
+      - name: run Posix specific tests
+        if: ${{ matrix.os.runs-on != 'windows-latest' }}
+        run: dotnet test PathLib.UnitTest.Posix

--- a/PathLib.UnitTest/PathUnitTest.cs
+++ b/PathLib.UnitTest/PathUnitTest.cs
@@ -85,7 +85,7 @@ namespace PathLib.UnitTest
         {
             var rootFilename = Guid.NewGuid().ToString();
             var rootPath = Path.Combine(_fixture.TempFolder, rootFilename);
-            File.Create(rootPath);
+            File.Create(rootPath).Dispose();
             IPath expected = _fixture.IsWindows
                 ? new WindowsPath(rootPath)
                 : new PosixPath(rootPath);

--- a/PathLib.UnitTest/PureWindowsPathUnitTest.cs
+++ b/PathLib.UnitTest/PureWindowsPathUnitTest.cs
@@ -387,7 +387,7 @@ namespace PathLib.UnitTest
             const string expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
 <XmlSerialize xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
   <Folder>c:\users\nemec</Folder>
-</XmlSerialize>";
+</XmlSerialize>".Replace("\r\n", "\n");
             var data = new XmlSerialize { Folder = new PureWindowsPath(@"c:\users\nemec") };
             var writer = new StringWriter(new StringBuilder());
 

--- a/PathLib.UnitTest/PureWindowsPathUnitTest.cs
+++ b/PathLib.UnitTest/PureWindowsPathUnitTest.cs
@@ -387,11 +387,12 @@ namespace PathLib.UnitTest
             const string expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
 <XmlSerialize xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
   <Folder>c:\users\nemec</Folder>
-</XmlSerialize>".Replace("\r\n", "\n");
+</XmlSerialize>";
             var data = new XmlSerialize { Folder = new PureWindowsPath(@"c:\users\nemec") };
             var writer = new StringWriter(new StringBuilder());
 
-            XmlWriterSettings ws = new XmlWriterSettings{ Indent = true};
+            XmlWriterSettings ws = new XmlWriterSettings{ Indent = true, NewLineChars = @"
+"};
             using(var xmlWriter = XmlWriter.Create(writer, ws)){
                 new XmlSerializer(typeof(XmlSerialize))
                     .Serialize(xmlWriter, data);


### PR DESCRIPTION
- Added a github action to run unit tests on Windows, Mac and Linux. you can run it manually. It will also run for each PR.
- Fixed some bugs in unit tests on Windows. There are still some tests that fail on Mac and Linux, but I don't know how to fix them.

---
I'm using PathLib in some projects of mine, so I would be glad to contribute to PathLib, including bug fixes and new features.