### PR TITLE
Remove ExtensionAttribute from LinqBridge.cs

### DIFF
--- a/PathLib/Utils/LinqBridge.cs
+++ b/PathLib/Utils/LinqBridge.cs
@@ -35,13 +35,6 @@ using System.Diagnostics;
 
 #pragma warning disable 1591
 
-namespace System.Runtime.CompilerServices
-{
-    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class
-         | AttributeTargets.Method)]
-    public sealed class ExtensionAttribute : Attribute { }
-}
-
 namespace PathLib.Utils
 {
     /// <summary>


### PR DESCRIPTION
Removed the ExtensionAttribute definition from the namespace System.Runtime.CompilerServices.

This causes `CS1685` warning when building on dotnet 10.0. This attribute should exist in `netstandard2.1` and `net4.5` target frameworks according to [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.extensionattribute?view=net-10.0#applies-to). Only mono platform may missing this before net4.0, but that target framework is not in our list now.

Fixes: https://github.com/nemec/pathlib/issues/24